### PR TITLE
add 6 services gated by tinyauth to the status page

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -71,6 +71,30 @@ sites:
     url: https://prog.students4students.ch
   - name: Madeam
     url: https://madeam.fr
+  - name: Change Detection
+    url: https://changedetection.androz2091.fr
+    expectedStatusCodes:
+      - 401
+  - name: Monica
+    url: https://monica.androz2091.fr
+    expectedStatusCodes:
+      - 401
+  - name: Grafana
+    url: https://prometheus-grafana.androz2091.fr
+    expectedStatusCodes:
+      - 401
+  - name: Radarr
+    url: https://radarr.androz2091.fr
+    expectedStatusCodes:
+      - 401
+  - name: Sonarr
+    url: https://sonarr.androz2091.fr
+    expectedStatusCodes:
+      - 401
+  - name: Tautulli
+    url: https://tautulli.androz2091.fr
+    expectedStatusCodes:
+      - 401
 
 status-website:
   cname: ismyserverworki.ng

--- a/history/androz2091-discord-redirection.yml
+++ b/history/androz2091-discord-redirection.yml
@@ -1,7 +1,7 @@
 url: https://androz2091.fr/discord
 status: up
 code: 302
-responseTime: 258
-lastUpdated: 2026-06-07T23:29:38.364Z
+responseTime: 136
+lastUpdated: 2026-06-08T04:57:28.876Z
 startTime: 2025-01-17T07:45:51.225Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/blog.yml
+++ b/history/blog.yml
@@ -1,7 +1,7 @@
 url: https://blog.androz2091.fr
 status: up
 code: 200
-responseTime: 321
-lastUpdated: 2026-06-07T23:29:14.761Z
+responseTime: 152
+lastUpdated: 2026-06-08T04:57:09.907Z
 startTime: 2022-05-18T20:01:34.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/change-detection.yml
+++ b/history/change-detection.yml
@@ -1,0 +1,7 @@
+url: https://changedetection.androz2091.fr
+status: up
+code: 401
+responseTime: 144
+lastUpdated: 2026-06-08T04:57:34.100Z
+startTime: 2026-06-08T04:57:33.955Z
+generator: Upptime <https://github.com/upptime/upptime>

--- a/history/ddpe.yml
+++ b/history/ddpe.yml
@@ -1,7 +1,7 @@
 url: https://ddpe.androz2091.fr
 status: up
 code: 200
-responseTime: 262
-lastUpdated: 2026-06-07T23:29:15.074Z
+responseTime: 156
+lastUpdated: 2026-06-08T04:57:10.101Z
 startTime: 2022-05-18T20:01:35.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/diswho.yml
+++ b/history/diswho.yml
@@ -1,7 +1,7 @@
 url: https://diswho.androz2091.fr
 status: up
 code: 200
-responseTime: 268
-lastUpdated: 2026-06-07T23:29:15.367Z
+responseTime: 233
+lastUpdated: 2026-06-08T04:57:10.366Z
 startTime: 2022-05-18T20:01:36.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/dumpus-api.yml
+++ b/history/dumpus-api.yml
@@ -1,7 +1,7 @@
 url: https://api.dumpus.app/health
 status: up
 code: 200
-responseTime: 2839
-lastUpdated: 2026-06-07T23:29:44.208Z
+responseTime: 2434
+lastUpdated: 2026-06-08T04:57:31.982Z
 startTime: 2026-05-17T01:21:12.454Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/dumpus-landing.yml
+++ b/history/dumpus-landing.yml
@@ -1,7 +1,7 @@
 url: https://dumpus.app
 status: up
 code: 200
-responseTime: 222
-lastUpdated: 2026-06-07T23:29:38.607Z
+responseTime: 141
+lastUpdated: 2026-06-08T04:57:29.049Z
 startTime: 2025-03-07T16:19:14.759Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/dumpus-web-client.yml
+++ b/history/dumpus-web-client.yml
@@ -1,7 +1,7 @@
 url: https://web.dumpus.app
 status: up
 code: 200
-responseTime: 436
-lastUpdated: 2026-06-07T23:29:41.346Z
+responseTime: 434
+lastUpdated: 2026-06-08T04:57:29.515Z
 startTime: 2025-03-07T16:19:15.668Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/file-browser.yml
+++ b/history/file-browser.yml
@@ -1,7 +1,7 @@
 url: https://cloud.androz2091.fr
 status: up
 code: 200
-responseTime: 364
-lastUpdated: 2026-06-07T23:29:18.344Z
+responseTime: 239
+lastUpdated: 2026-06-08T04:57:11.821Z
 startTime: 2024-03-17T13:04:02.260Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/flep-guessr.yml
+++ b/history/flep-guessr.yml
@@ -1,7 +1,7 @@
 url: https://flepguessr-cs214.androz2091.fr
 status: up
 code: 200
-responseTime: 230
-lastUpdated: 2026-06-07T23:29:37.802Z
+responseTime: 139
+lastUpdated: 2026-06-08T04:57:28.452Z
 startTime: 2024-12-12T21:48:46.846Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/grafana.yml
+++ b/history/grafana.yml
@@ -1,0 +1,7 @@
+url: https://prometheus-grafana.androz2091.fr
+status: up
+code: 401
+responseTime: 136
+lastUpdated: 2026-06-08T04:57:34.790Z
+startTime: 2026-06-08T04:57:34.652Z
+generator: Upptime <https://github.com/upptime/upptime>

--- a/history/h5ai-servarr.yml
+++ b/history/h5ai-servarr.yml
@@ -1,7 +1,7 @@
 url: https://h5ai-servarr.androz2091.fr
 status: up
 code: 401
-responseTime: 261
-lastUpdated: 2026-06-07T23:29:38.084Z
+responseTime: 223
+lastUpdated: 2026-06-08T04:57:28.707Z
 startTime: 2024-12-30T13:32:19.356Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/harbor.yml
+++ b/history/harbor.yml
@@ -1,7 +1,7 @@
 url: https://harbor.androz2091.fr
 status: up
 code: 200
-responseTime: 270
-lastUpdated: 2026-06-07T23:29:35.928Z
+responseTime: 235
+lastUpdated: 2026-06-08T04:57:27.344Z
 startTime: 2024-09-17T08:28:02.778Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/haste-server.yml
+++ b/history/haste-server.yml
@@ -1,7 +1,7 @@
 url: https://haste.androz2091.fr
 status: up
 code: 200
-responseTime: 382
-lastUpdated: 2026-06-07T23:29:19.080Z
+responseTime: 228
+lastUpdated: 2026-06-08T04:57:12.271Z
 startTime: 2024-03-17T13:04:03.112Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/immich.yml
+++ b/history/immich.yml
@@ -1,7 +1,7 @@
 url: https://photos.androz2091.fr
 status: up
 code: 200
-responseTime: 299
-lastUpdated: 2026-06-07T23:29:18.665Z
+responseTime: 150
+lastUpdated: 2026-06-08T04:57:12.003Z
 startTime: 2024-03-17T13:04:02.706Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/instaddict.yml
+++ b/history/instaddict.yml
@@ -1,7 +1,7 @@
 url: https://instaddict.androz2091.fr
 status: up
 code: 200
-responseTime: 927
-lastUpdated: 2026-06-07T23:29:20.714Z
+responseTime: 609
+lastUpdated: 2026-06-08T04:57:13.376Z
 startTime: 2022-05-18T20:01:53.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/madeam.yml
+++ b/history/madeam.yml
@@ -1,7 +1,7 @@
 url: https://madeam.fr
 status: up
 code: 200
-responseTime: 1028
-lastUpdated: 2026-06-07T23:29:47.360Z
+responseTime: 829
+lastUpdated: 2026-06-08T04:57:33.926Z
 startTime: 2025-05-03T08:17:28.710Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/main-website-ndd-androz2091.yml
+++ b/history/main-website-ndd-androz2091.yml
@@ -1,7 +1,7 @@
 url: https://androz2091.fr
 status: up
 code: 200
-responseTime: 294
-lastUpdated: 2026-06-07T23:29:36.244Z
+responseTime: 153
+lastUpdated: 2026-06-08T04:57:27.530Z
 startTime: 2024-10-17T09:43:32.738Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/main-website-ndd-simonlefort-ch.yml
+++ b/history/main-website-ndd-simonlefort-ch.yml
@@ -1,7 +1,7 @@
 url: https://simonlefort.ch
 status: up
 code: 200
-responseTime: 731
-lastUpdated: 2026-06-07T23:29:37.550Z
+responseTime: 252
+lastUpdated: 2026-06-08T04:57:28.280Z
 startTime: 2025-05-03T08:17:12.213Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/main-website-ndd-simonlefort-fr.yml
+++ b/history/main-website-ndd-simonlefort-fr.yml
@@ -1,7 +1,7 @@
 url: https://simonlefort.fr
 status: up
 code: 200
-responseTime: 531
-lastUpdated: 2026-06-07T23:29:36.797Z
+responseTime: 430
+lastUpdated: 2026-06-08T04:57:27.994Z
 startTime: 2025-05-03T08:17:10.903Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/manage-invite-api.yml
+++ b/history/manage-invite-api.yml
@@ -1,7 +1,7 @@
 url: https://api.manage-invite.xyz
 status: down
 code: 502
-responseTime: 183
-lastUpdated: 2026-06-07T23:29:34.206Z
+responseTime: 56
+lastUpdated: 2026-06-08T04:57:26.411Z
 startTime: 2022-12-17T10:10:25.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/manage-invite.yml
+++ b/history/manage-invite.yml
@@ -1,7 +1,7 @@
 url: https://manage-invite.xyz
 status: up
 code: 200
-responseTime: 230
-lastUpdated: 2026-06-07T23:29:21.674Z
+responseTime: 283
+lastUpdated: 2026-06-08T04:57:14.190Z
 startTime: 2022-05-18T20:01:59.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/monica.yml
+++ b/history/monica.yml
@@ -1,0 +1,7 @@
+url: https://monica.androz2091.fr
+status: up
+code: 401
+responseTime: 140
+lastUpdated: 2026-06-08T04:57:34.427Z
+startTime: 2026-06-08T04:57:34.286Z
+generator: Upptime <https://github.com/upptime/upptime>

--- a/history/online-love-calc.yml
+++ b/history/online-love-calc.yml
@@ -1,7 +1,7 @@
 url: https://love-calc.androz2091.fr
 status: up
 code: 200
-responseTime: 373
-lastUpdated: 2026-06-07T23:29:21.110Z
+responseTime: 293
+lastUpdated: 2026-06-08T04:57:13.702Z
 startTime: 2022-05-18T20:01:55.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/overseerr.yml
+++ b/history/overseerr.yml
@@ -1,7 +1,7 @@
 url: https://overseerr.androz2091.fr
 status: up
 code: 200
-responseTime: 1503
-lastUpdated: 2026-06-07T23:29:17.958Z
+responseTime: 377
+lastUpdated: 2026-06-08T04:57:11.549Z
 startTime: 2025-02-01T17:21:57.996Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/pdf-ding.yml
+++ b/history/pdf-ding.yml
@@ -1,7 +1,7 @@
 url: https://pdfding.androz2091.fr
 status: up
 code: 200
-responseTime: 826
-lastUpdated: 2026-06-07T23:29:45.055Z
+responseTime: 332
+lastUpdated: 2026-06-08T04:57:32.345Z
 startTime: 2025-05-03T08:17:24.568Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/plex.yml
+++ b/history/plex.yml
@@ -1,7 +1,7 @@
 url: https://plex.androz2091.fr/web/index.html
 status: up
 code: 200
-responseTime: 544
-lastUpdated: 2026-06-07T23:29:16.434Z
+responseTime: 238
+lastUpdated: 2026-06-08T04:57:11.140Z
 startTime: 2022-05-18T20:01:40.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/q-bittorrent.yml
+++ b/history/q-bittorrent.yml
@@ -1,7 +1,7 @@
 url: https://qbt.androz2091.fr
 status: up
 code: 200
-responseTime: 233
-lastUpdated: 2026-06-07T23:29:19.766Z
+responseTime: 238
+lastUpdated: 2026-06-08T04:57:12.735Z
 startTime: 2022-05-18T20:01:52.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/radarr.yml
+++ b/history/radarr.yml
@@ -1,0 +1,7 @@
+url: https://radarr.androz2091.fr
+status: up
+code: 401
+responseTime: 138
+lastUpdated: 2026-06-08T04:57:35.121Z
+startTime: 2026-06-08T04:57:34.982Z
+generator: Upptime <https://github.com/upptime/upptime>

--- a/history/s4-s-programming-website.yml
+++ b/history/s4-s-programming-website.yml
@@ -1,7 +1,7 @@
 url: https://prog.students4students.ch
 status: up
 code: 200
-responseTime: 1232
-lastUpdated: 2026-06-07T23:29:46.310Z
+responseTime: 689
+lastUpdated: 2026-06-08T04:57:33.066Z
 startTime: 2025-05-03T08:17:26.510Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/slash-commands-gui.yml
+++ b/history/slash-commands-gui.yml
@@ -1,7 +1,7 @@
 url: https://slash-commands-gui.androz2091.fr
 status: up
 code: 200
-responseTime: 290
-lastUpdated: 2026-06-07T23:29:21.422Z
+responseTime: 141
+lastUpdated: 2026-06-08T04:57:13.874Z
 startTime: 2022-05-18T20:01:56.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/sonarr.yml
+++ b/history/sonarr.yml
@@ -1,0 +1,7 @@
+url: https://sonarr.androz2091.fr
+status: up
+code: 401
+responseTime: 139
+lastUpdated: 2026-06-08T04:57:35.513Z
+startTime: 2026-06-08T04:57:35.373Z
+generator: Upptime <https://github.com/upptime/upptime>

--- a/history/stale-manage-invite-api.yml
+++ b/history/stale-manage-invite-api.yml
@@ -1,7 +1,7 @@
 url: https://dash.manage-invite.xyz
 status: up
 code: 200
-responseTime: 824
-lastUpdated: 2026-06-07T23:29:35.052Z
+responseTime: 134
+lastUpdated: 2026-06-08T04:57:26.578Z
 startTime: 2022-12-19T15:18:26.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/tagger.yml
+++ b/history/tagger.yml
@@ -1,7 +1,7 @@
 url: https://timetagger.androz2091.fr
 status: up
 code: 200
-responseTime: 562
-lastUpdated: 2026-06-07T23:29:35.636Z
+responseTime: 465
+lastUpdated: 2026-06-08T04:57:27.076Z
 startTime: 2022-10-27T10:19:17.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/tautulli.yml
+++ b/history/tautulli.yml
@@ -1,0 +1,7 @@
+url: https://tautulli.androz2091.fr
+status: up
+code: 401
+responseTime: 138
+lastUpdated: 2026-06-08T04:57:35.913Z
+startTime: 2026-06-08T04:57:35.774Z
+generator: Upptime <https://github.com/upptime/upptime>

--- a/history/umami-analytics.yml
+++ b/history/umami-analytics.yml
@@ -1,7 +1,7 @@
 url: https://analytics.androz2091.fr
 status: up
 code: 200
-responseTime: 479
-lastUpdated: 2026-06-07T23:29:15.867Z
+responseTime: 471
+lastUpdated: 2026-06-08T04:57:10.869Z
 startTime: 2022-05-18T20:01:37.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/vault-warden.yml
+++ b/history/vault-warden.yml
@@ -1,7 +1,7 @@
 url: https://vault.androz2091.fr
 status: up
 code: 200
-responseTime: 409
-lastUpdated: 2026-06-07T23:29:19.511Z
+responseTime: 162
+lastUpdated: 2026-06-08T04:57:12.465Z
 startTime: 2022-06-10T15:18:10.000Z
 generator: Upptime <https://github.com/upptime/upptime>


### PR DESCRIPTION
Change Detection, Monica, Grafana, Radarr, Sonarr, and Tautulli were
recently re-exposed publicly behind tinyauth forward auth in the k8s
cluster. Each one returns 401 to an unauthenticated probe, so the
expectedStatusCodes mirrors the h5ai entry.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>